### PR TITLE
Improve "Show replies" button appearance

### DIFF
--- a/app/src/main/res/layout/list_comments_item.xml
+++ b/app/src/main/res/layout/list_comments_item.xml
@@ -111,7 +111,7 @@
     <Button
         android:id="@+id/itemContentReplyButton"
         style="?android:attr/borderlessButtonStyle"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/detail_thumbs_up_img_view"
         android:layout_toEndOf="@+id/itemThumbnailView"
@@ -119,7 +119,12 @@
         android:layout="@id/detail_heart_image_view"
         android:text="@string/show_comment_reply"
         android:textAppearance="?android:attr/textAppearanceLarge"
-        android:textColor="@android:color/holo_blue_dark"
-        android:textSize="@dimen/comment_item_content_text_size" />
+        android:textColor="@color/show_replies_button_text_color"
+        android:textSize="@dimen/comment_item_content_text_size"
+        android:gravity="start|center_vertical"
+        android:layout_marginTop="4dp"
+        android:minHeight="0dp"
+        android:paddingVertical="6dp"
+        android:paddingHorizontal="4dp" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/list_comments_mini_item.xml
+++ b/app/src/main/res/layout/list_comments_mini_item.xml
@@ -69,7 +69,7 @@
     <Button
         android:id="@+id/itemContentReplyButton"
         style="?android:attr/borderlessButtonStyle"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/detail_thumbs_up_img_view"
         android:layout_toEndOf="@+id/itemThumbnailView"
@@ -77,7 +77,12 @@
         android:layout="@id/detail_heart_image_view"
         android:text="@string/show_comment_reply"
         android:textAppearance="?android:attr/textAppearanceLarge"
-        android:textColor="@android:color/holo_blue_dark"
-        android:textSize="@dimen/comment_item_content_text_size" />
+        android:textColor="@color/show_replies_button_text_color"
+        android:textSize="@dimen/comment_item_content_text_size"
+        android:gravity="start|center_vertical"
+        android:layout_marginTop="4dp"
+        android:minHeight="0dp"
+        android:paddingVertical="6dp"
+        android:paddingHorizontal="4dp" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -64,6 +64,8 @@
     <color name="subscribed_background_color">#d6d6d6</color>
     <color name="subscribed_text_color">#717171</color>
 
+    <color name="show_replies_button_text_color">#0276aa</color>
+
     <color name="transparent_background_color">#00000000</color>
     <color name="selected_background_color">#96717171</color>
 


### PR DESCRIPTION
Upstream conversation: https://github.com/TeamNewPipe/NewPipe/pull/9020

- Reduced "Show replies" button padding
- Extended button's width to match parent
- Picked a consistent material color for its text
- Added a little spacing between the comment and button / its highlight